### PR TITLE
Show only bounding box ID

### DIFF
--- a/script.js
+++ b/script.js
@@ -187,7 +187,7 @@ class ImageAnnotationTool {
         // Add label
         const label = document.createElement('div');
         label.className = 'box-label';
-        label.textContent = `${index}: ${boxData.content || 'No content'}`;
+        label.textContent = `${index}`;
         boxElement.appendChild(label);
         
         // Add resize handles
@@ -408,7 +408,7 @@ class ImageAnnotationTool {
             if (property === 'content') {
                 const boxElement = this.boundingBoxesContainer.children[this.selectedBoxIndex];
                 const label = boxElement.querySelector('.box-label');
-                label.textContent = `${this.selectedBoxIndex}: ${value || 'No content'}`;
+                label.textContent = `${this.selectedBoxIndex}`;
             }
         }
     }
@@ -492,7 +492,7 @@ class ImageAnnotationTool {
             ctx.strokeRect(x, y, width, height);
             
             // Draw label
-            const label = `${index}: ${box.content || 'No content'}`;
+            const label = `${index}`;
             ctx.fillStyle = '#e74c3c';
             ctx.fillRect(x, y - 20, ctx.measureText(label).width + 10, 20);
             ctx.fillStyle = 'white';


### PR DESCRIPTION
Refactor: Display only bounding box ID to prevent text overlap.

The previous implementation displayed both the bounding box ID and its content within the label, leading to text overlap and visual clutter, especially with longer content. This change ensures a cleaner interface by showing only the ID, while full content remains accessible via the right-side panel.

---
<a href="https://cursor.com/background-agent?bcId=bc-145061c1-f764-40dd-88ae-8f3ad4c82b51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-145061c1-f764-40dd-88ae-8f3ad4c82b51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

